### PR TITLE
Feature/tcp send

### DIFF
--- a/Electron/.eslintrc.js
+++ b/Electron/.eslintrc.js
@@ -15,6 +15,7 @@ module.exports = {
     "react/destructuring-assignment": "off",
     "@typescript-eslint/no-empty-interface": "off",
     "react/no-access-state-in-setstate": "off",
+    "no-restricted-syntax": "off",
     "no-plusplus": "off",
     semi: [2, "never"],
     "react/jsx-filename-extension": [

--- a/Electron/Core/RoveProtocol/Rovecomm.ts
+++ b/Electron/Core/RoveProtocol/Rovecomm.ts
@@ -152,8 +152,9 @@ class Rovecomm extends EventEmitter {
     )
 
     this.UDPListen()
-    this.TCPServer.listen(11111)
+    this.TCPServer.listen(11110)
     this.createTCPConnection(11111, "192.168.0.12")
+    this.createTCPConnection(11110, "192.168.0.12")
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   }
 
@@ -162,12 +163,8 @@ class Rovecomm extends EventEmitter {
     await temp.connect(port, host, function handler() {
       console.log(`Connected to ${host} on Port: ${port}`)
     })
-    console.log(temp)
     this.TCPConnections.push(temp)
-    console.log(this.TCPConnections)
-    /* this.TCPConnections[-1].connect(port, host, function handler() {
-      console.log(`Created connection to ${host} on Port: ${port}`)
-    }) */
+    // should this also subscribe to the board over TCP? Probably not since that should be UDP traffic, right?
   }
 
   UDPListen() {
@@ -190,12 +187,21 @@ class Rovecomm extends EventEmitter {
   }
 
   sendTCP(packet: Buffer, destinationIp: string, port: number) {
-    const temp = this.TCPConnections[0]
-    this.TCPConnections[0].write(packet, "utf8", function handler() {
-      console.log(
-        `wrote ${packet} to ${temp.remoteAddress} on ${temp.remotePort}`
-      )
-    })
+    // eslint-disable-next-line no-restricted-syntax
+    for (const socket in this.TCPConnections) {
+      if (
+        this.TCPConnections[socket].remoteAddress === destinationIp &&
+        this.TCPConnections[socket].remotePort === port
+      ) {
+        const temp = this.TCPConnections[socket]
+        this.TCPConnections[socket].write(packet, "utf8", function handler() {
+          console.log(
+            `wrote ${packet} to ${temp.remoteAddress} on ${temp.remotePort}`
+          )
+        })
+        break
+      }
+    }
   }
 
   // While most "any" variable types have been removed, data really can be almost any type

--- a/Electron/Core/RoveProtocol/Rovecomm.ts
+++ b/Electron/Core/RoveProtocol/Rovecomm.ts
@@ -232,7 +232,6 @@ class Rovecomm extends EventEmitter {
       // New Data flag, to determine if we need to parse or not (async read)
       newData: false,
     }
-    newSocket.RCSocket = new net.Socket()
 
     // Connect to the board we're intending to communicate with
     newSocket.RCSocket.connect(port, host, function handler() {

--- a/Electron/Core/RoveProtocol/Rovecomm.ts
+++ b/Electron/Core/RoveProtocol/Rovecomm.ts
@@ -144,7 +144,7 @@ function TCPParseWrapper(socket: TCPSocket) {
       header.push(socket.RCDeque.get(i))
     }
     // If the length of the Deque is more than the header size and the size of the packet, make a buffer and then parse that buffer
-    if (socket.RCDeque.length > header[3] * header[4] + 5) {
+    if (socket.RCDeque.length > 5 + header[3] * header[4]) {
       // create another list to put the entire packet into
       const packet = []
       for (let i = 0; i < 5 + header[3] * header[4]; i++) {

--- a/Electron/Core/RoveProtocol/Rovecomm.ts
+++ b/Electron/Core/RoveProtocol/Rovecomm.ts
@@ -199,6 +199,7 @@ class Rovecomm extends EventEmitter {
 
     this.UDPListen()
     // this.TCPServer.listen(11111)
+    this.createTCPConnection(11001, "192.168.1.131")
     this.resubscribe = this.resubscribe.bind(this)
   }
 
@@ -264,6 +265,7 @@ class Rovecomm extends EventEmitter {
   sendTCP(packet: Buffer, destinationIp: string, port: number) {
     // eslint-disable-next-line no-restricted-syntax
     for (const socket in this.TCPConnections) {
+      // TODO: When the boards all change to a single port, remove that check from this if statement
       if (
         this.TCPConnections[socket].RCSocket.remoteAddress === destinationIp &&
         this.TCPConnections[socket].RCSocket.remotePort === port

--- a/Electron/Core/RoveProtocol/Rovecomm.ts
+++ b/Electron/Core/RoveProtocol/Rovecomm.ts
@@ -141,6 +141,7 @@ function TCPParseWrapper(socket: TCPSocket) {
     const header = []
     for (let i = 0; i < 5; i++) {
       // Fill the list with the header contents, the first 5 bytes will only ever be the header of a packet if we read correctly
+      // Here we use get to acquire the values of the fist 5 entries without modifying the Deque, listed as an O(1) function
       header.push(socket.RCDeque.get(i))
     }
     // If the length of the Deque is more than the header size and the size of the packet, make a buffer and then parse that buffer
@@ -148,6 +149,7 @@ function TCPParseWrapper(socket: TCPSocket) {
       // create another list to put the entire packet into
       const packet = []
       for (let i = 0; i < 5 + header[3] * header[4]; i++) {
+        // Here we use Shift to get and remove the elements that make up the packet to prevent parsing the same packet multiple times
         packet.push(socket.RCDeque.shift())
       }
       // Make a buffer from that list
@@ -179,7 +181,7 @@ function TCPListen(socket: TCPSocket) {
 class Rovecomm extends EventEmitter {
   UDPSocket: Socket
 
-  TCPServer: Server
+  // TCPServer: Server
 
   TCPConnections: TCPSocket[]
 
@@ -189,15 +191,14 @@ class Rovecomm extends EventEmitter {
     // Initialization of UDP socket and server
     this.UDPSocket = dgram.createSocket("udp4")
     // TCPServer is purely for testing purposes and should not be relied on for use on Rover
-    this.TCPServer = net.createServer((TCPSocket: Socket) =>
+    /* this.TCPServer = net.createServer((TCPSocket: Socket) =>
       TCPSocket.on("data", (msg: Buffer) => {
         this.parse(msg)
       })
-    )
+    ) */
 
     this.UDPListen()
-    this.TCPServer.listen(11111)
-    this.createTCPConnection(11001, "192.168.1.131")
+    // this.TCPServer.listen(11111)
     this.resubscribe = this.resubscribe.bind(this)
   }
 

--- a/Electron/Core/RoveProtocol/Rovecomm.ts
+++ b/Electron/Core/RoveProtocol/Rovecomm.ts
@@ -1,6 +1,12 @@
 import { Socket } from "dgram"
 import Deque from "double-ended-queue"
-import { DATAID, dataSizes, DataTypes, headerLength } from "./RovecommManifest"
+import {
+  DATAID,
+  dataSizes,
+  DataTypes,
+  headerLength,
+  SystemPackets,
+} from "./RovecommManifest"
 
 // There is a fundamental implementation difference between these required imports
 // and the traditional typescript imports.
@@ -396,17 +402,17 @@ class Rovecomm extends EventEmitter {
 
   resubscribe() {
     const VersionNumber = 2
-    const dataId = 3
+    const dataId = SystemPackets.SUBSCRIBE
     const dataLength = 0
     const dataType = DataTypes.UINT8_T
     const data = 0
 
-    const subscribe = Buffer.allocUnsafe(6)
+    const subscribe = Buffer.allocUnsafe(headerLength + 1)
     subscribe.writeUInt8(VersionNumber, 0)
     subscribe.writeUInt16BE(dataId, 1)
     subscribe.writeUInt8(dataLength, 3)
     subscribe.writeUInt8(dataType, 4)
-    subscribe.writeUInt8(data, 5)
+    subscribe.writeUInt8(data, headerLength)
 
     for (let i = 0; i < DATAID.length; i++) {
       this.sendUDP(subscribe, DATAID[i].Ip)

--- a/Electron/Core/RoveProtocol/Rovecomm.ts
+++ b/Electron/Core/RoveProtocol/Rovecomm.ts
@@ -126,7 +126,7 @@ function parse(packet: Buffer): void {
   }
 }
 
-function TCPListen(socket) {
+function TCPListen(socket: Socket) {
   /*
    * Listens on the passed in TCP socket, always calling parse if it recieves anything
    */
@@ -140,11 +140,11 @@ class Rovecomm extends EventEmitter {
 
   TCPServer: Server
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  TCPConnections = new net.Socket()
+  TCPConnections: Socket[]
 
   constructor() {
     super()
+    this.TCPConnections = []
     // Initialization of UDP socket and server
     this.UDPSocket = dgram.createSocket("udp4")
     this.TCPServer = net.createServer((TCPSocket: Socket) =>
@@ -155,15 +155,15 @@ class Rovecomm extends EventEmitter {
     this.TCPServer.listen(11111)
     this.createTCPConnection(11111, "192.168.0.12")
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    this.TCPConnections.on("data", function handler(data: any) {
-      console.log(data)
-    })
   }
 
   async createTCPConnection(port: number, host = "localhost") {
-    this.TCPConnections.connect(port, host, function handler() {
+    const temp = await new net.Socket()
+    await temp.connect(port, host, function handler() {
       console.log(`Connected to ${host} on Port: ${port}`)
     })
+    console.log(temp)
+    this.TCPConnections.push(temp)
     console.log(this.TCPConnections)
     /* this.TCPConnections[-1].connect(port, host, function handler() {
       console.log(`Created connection to ${host} on Port: ${port}`)
@@ -190,8 +190,8 @@ class Rovecomm extends EventEmitter {
   }
 
   sendTCP(packet: Buffer, destinationIp: string, port: number) {
-    const temp = this.TCPConnections
-    this.TCPConnections.write(packet, "utf8", function handler() {
+    const temp = this.TCPConnections[0]
+    this.TCPConnections[0].write(packet, "utf8", function handler() {
       console.log(
         `wrote ${packet} to ${temp.remoteAddress} on ${temp.remotePort}`
       )

--- a/Electron/Core/RoveProtocol/Rovecomm.ts
+++ b/Electron/Core/RoveProtocol/Rovecomm.ts
@@ -153,14 +153,25 @@ class Rovecomm extends EventEmitter {
 
     this.UDPListen()
     this.TCPServer.listen(11110)
-    this.createTCPConnection(11111, "192.168.0.12")
     this.createTCPConnection(11110, "192.168.0.12")
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
   }
 
-  async createTCPConnection(port: number, host = "localhost") {
-    const temp = await new net.Socket()
-    await temp.connect(port, host, function handler() {
+  createTCPConnection(port: number, host = "localhost") {
+    console.log(host, port)
+    // eslint-disable-next-line no-restricted-syntax
+    for (const socket in this.TCPConnections) {
+      if (
+        this.TCPConnections[socket].remoteAddress === host &&
+        this.TCPConnections[socket].remotePort === port
+      ) {
+        console.log(
+          `Attempted to add a second connection to ${host}:${port}, didn't add`
+        )
+        return
+      }
+    }
+    const temp = new net.Socket()
+    temp.connect(port, host, function handler() {
       console.log(`Connected to ${host} on Port: ${port}`)
     })
     this.TCPConnections.push(temp)

--- a/Electron/Core/RoveProtocol/Rovecomm.ts
+++ b/Electron/Core/RoveProtocol/Rovecomm.ts
@@ -12,7 +12,6 @@ const EventEmitter = require("events")
 
 interface TCPSocket {
   RCSocket: Socket
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   RCDeque: Deque<any>
   newData: boolean
 }

--- a/Electron/Core/RoveProtocol/Rovecomm.ts
+++ b/Electron/Core/RoveProtocol/Rovecomm.ts
@@ -140,7 +140,7 @@ function TCPParseWrapper(socket: TCPSocket) {
     const dataCount = socket.RCDeque.get(3)
     const dataSize = dataSizes[socket.RCDeque.get(4)]
     // If the length of the Deque is more than the header size and the size of the packet, make a buffer and then parse that buffer
-    if (socket.RCDeque.length > 5 + dataCount * dataSize) {
+    if (socket.RCDeque.length >= 5 + dataCount * dataSize) {
       // create another list to put the entire packet into
       const packet = []
       for (let i = 0; i < 5 + dataCount * dataSize; i++) {

--- a/Electron/Core/RoveProtocol/Rovecomm.ts
+++ b/Electron/Core/RoveProtocol/Rovecomm.ts
@@ -1,5 +1,4 @@
 import { Socket } from "dgram"
-import { Server } from "http"
 import Deque from "double-ended-queue"
 import { DATAID, dataSizes, DataTypes, headerLength } from "./RovecommManifest"
 
@@ -99,7 +98,6 @@ function parse(packet: Buffer): void {
     // Here we loop through all of the Boards in the manifest,
     // looking specifically if this dataId is a known Telemetry of the board
     for (let i = 0; i < DATAID.length; i++) {
-      // eslint-disable-next-line no-restricted-syntax
       for (const comm in DATAID[i].Telemetry) {
         if (dataId === DATAID[i].Telemetry[comm].dataId) {
           dataIdStr = comm
@@ -192,7 +190,6 @@ class Rovecomm extends EventEmitter {
      * Creates a connection to the target Host:Port over TCP, if a connection doesn't already exist
      * Runs the TCPListen function on the new TCPSocket, then pushes the new TCPSocket into the rovecomm TCPConnections list
      */
-    // eslint-disable-next-line no-restricted-syntax
     for (const socket in this.TCPConnections) {
       if (
         this.TCPConnections[socket].RCSocket.remoteAddress === host &&
@@ -255,7 +252,6 @@ class Rovecomm extends EventEmitter {
      * Sends the packet if there's a connection with the correct IP:Port combination
      * If there is no connection, emits an error message
      */
-    // eslint-disable-next-line no-restricted-syntax
     for (const socket in this.TCPConnections) {
       // TODO: When the boards all change to a single port, remove that check from this if statement
       if (

--- a/Electron/Core/RoveProtocol/Rovecomm.ts
+++ b/Electron/Core/RoveProtocol/Rovecomm.ts
@@ -11,13 +11,13 @@ const EventEmitter = require("events")
 
 function decodePacket(
   dataType: number,
-  DataCount: number,
+  dataCount: number,
   data: Buffer
 ): number[] {
   /*
    * Takes in a dataType, dateLength, and data from an incoming rovecomm packet,
    * and uses the dataType to return an array of the properly typed data.
-   * Note: even if DataCount is only 1, this returns an array of one item.
+   * Note: even if dataCount is only 1, this returns an array of one item.
    */
 
   let readBytes: (i: number) => number
@@ -50,7 +50,7 @@ function decodePacket(
 
   const retArray = []
   let offset: number
-  for (let i = 0; i < DataCount; i += 1) {
+  for (let i = 0; i < dataCount; i += 1) {
     offset = i * dataSizes[dataType]
     retArray.push(readBytes(offset))
   }
@@ -79,14 +79,14 @@ function parse(packet: Buffer): void {
 
   const version = packet.readUInt8(0)
   const dataId = packet.readUInt16BE(1)
-  const DataCount = packet.readUInt8(3)
+  const dataCount = packet.readUInt8(3)
   const dataType = packet.readUInt8(4)
 
   const rawdata = packet.slice(5)
   let data: number[]
 
   if (version === VersionNumber) {
-    data = decodePacket(dataType, DataCount, rawdata)
+    data = decodePacket(dataType, dataCount, rawdata)
 
     let dataIdStr = "null"
     let endLoop = false
@@ -118,7 +118,7 @@ function parse(packet: Buffer): void {
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
     rovecomm.emit(
       "all",
-      `Data Id: ${dataId} (aka ${dataIdStr}), Type: ${dataType}, Length: ${DataCount}, Data: ${data}`
+      `Data Id: ${dataId} (aka ${dataIdStr}), Type: ${dataType}, Count: ${dataCount}, Data: ${data}`
     )
 
     // More emits will potentially follow to allow RON to listen to only a certain board,
@@ -152,8 +152,8 @@ class Rovecomm extends EventEmitter {
     )
 
     this.UDPListen()
-    this.TCPServer.listen(11110)
-    this.createTCPConnection(11110, "192.168.0.12")
+    this.TCPServer.listen(11111)
+    this.createTCPConnection(11111)
     this.resubscribe = this.resubscribe.bind(this)
   }
 
@@ -225,7 +225,7 @@ class Rovecomm extends EventEmitter {
      */
     const VersionNumber = 2
 
-    const DataCount = data.length
+    const dataCount = data.length
     let destinationIp = ""
     let port = 11000
     let dataType
@@ -253,16 +253,16 @@ class Rovecomm extends EventEmitter {
      *  |   Data Type   |                Data (Variable)                |
      *  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
      *
-     *  Note: the size of Data is DataCount * dataSizes[DataType] bytes
+     *  Note: the size of Data is dataCount * dataSizes[DataType] bytes
      */
     const headerBuffer = Buffer.allocUnsafe(5)
     headerBuffer.writeUInt8(VersionNumber, 0)
     headerBuffer.writeUInt16BE(dataId, 1)
-    headerBuffer.writeUInt8(DataCount, 3)
+    headerBuffer.writeUInt8(dataCount, 3)
     headerBuffer.writeUInt8(dataType, 4)
 
     // Create the data buffer
-    const dataBuffer = Buffer.allocUnsafe(DataCount * dataSizes[dataType])
+    const dataBuffer = Buffer.allocUnsafe(dataCount * dataSizes[dataType])
 
     // Switch on the data type, and properly encode each number in the data
     // array depending on the enumerated type, computing the offset and pushing

--- a/Electron/Core/RoveProtocol/Rovecomm.ts
+++ b/Electron/Core/RoveProtocol/Rovecomm.ts
@@ -152,25 +152,18 @@ class Rovecomm extends EventEmitter {
     )
 
     this.UDPListen()
-    this.TCPServer.listen(11110)
-    this.createTCPConnection(11110, "192.168.0.12")
+    this.TCPServer.listen(11111)
+    this.createTCPConnection(11111, "192.168.0.12")
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     this.TCPConnections.on("data", function handler(data: any) {
-      console.log(data.to_String())
+      console.log(data)
     })
-  }
-
-  // eslint-disable-next-line class-methods-use-this
-  async sleep(ms: number) {
-    // eslint-disable-next-line no-new
-    new Promise(resolve => setTimeout(() => resolve(true), ms * 1000))
   }
 
   async createTCPConnection(port: number, host = "localhost") {
     this.TCPConnections.connect(port, host, function handler() {
       console.log(`Connected to ${host} on Port: ${port}`)
     })
-    await this.sleep(1000)
     console.log(this.TCPConnections)
     /* this.TCPConnections[-1].connect(port, host, function handler() {
       console.log(`Created connection to ${host} on Port: ${port}`)
@@ -185,7 +178,7 @@ class Rovecomm extends EventEmitter {
     this.UDPSocket.on("message", (msg: Buffer) => {
       parse(msg)
     })
-    this.UDPSocket.bind(10000)
+    this.UDPSocket.bind(11000)
   }
 
   sendUDP(packet: Buffer, destinationIp: string, port = 11000): void {

--- a/Electron/Core/RoveProtocol/Rovecomm.ts
+++ b/Electron/Core/RoveProtocol/Rovecomm.ts
@@ -152,7 +152,7 @@ function TCPParseWrapper(socket: TCPSocket) {
         // Here we use Shift to get and remove the elements that make up the packet to prevent parsing the same packet multiple times
         packet.push(socket.RCDeque.shift())
       }
-      // Make a buffer from that list
+      // Make a buffer from that list, needed to provide the correct input for the parse function
       const packetBuffer = Buffer.from(packet)
       parse(packetBuffer)
       // If the Deque doesn't contain a full packet, return

--- a/Electron/Core/RoveProtocol/Rovecomm.ts
+++ b/Electron/Core/RoveProtocol/Rovecomm.ts
@@ -137,18 +137,13 @@ function parse(packet: Buffer): void {
 function TCPParseWrapper(socket: TCPSocket) {
   // While the Deque contains at least a header to allow parsing control packets
   while (socket.RCDeque.length >= 5) {
-    // Create an empty list to fill with the header contents
-    const header = []
-    for (let i = 0; i < 5; i++) {
-      // Fill the list with the header contents, the first 5 bytes will only ever be the header of a packet if we read correctly
-      // Here we use get to acquire the values of the fist 5 entries without modifying the Deque, listed as an O(1) function
-      header.push(socket.RCDeque.get(i))
-    }
+    const dataCount = socket.RCDeque.get(3)
+    const dataSize = dataSizes[socket.RCDeque.get(4)]
     // If the length of the Deque is more than the header size and the size of the packet, make a buffer and then parse that buffer
-    if (socket.RCDeque.length > 5 + header[3] * header[4]) {
+    if (socket.RCDeque.length > 5 + dataCount * dataSize) {
       // create another list to put the entire packet into
       const packet = []
-      for (let i = 0; i < 5 + header[3] * header[4]; i++) {
+      for (let i = 0; i < 5 + dataCount * dataSize; i++) {
         // Here we use Shift to get and remove the elements that make up the packet to prevent parsing the same packet multiple times
         packet.push(socket.RCDeque.shift())
       }
@@ -199,7 +194,6 @@ class Rovecomm extends EventEmitter {
 
     this.UDPListen()
     // this.TCPServer.listen(11111)
-    this.createTCPConnection(11001, "192.168.1.131")
     this.resubscribe = this.resubscribe.bind(this)
   }
 

--- a/Electron/Core/RoveProtocol/Rovecomm.ts
+++ b/Electron/Core/RoveProtocol/Rovecomm.ts
@@ -432,6 +432,7 @@ class Rovecomm extends EventEmitter {
 
     for (let i = 0; i < DATAID.length; i++) {
       this.sendUDP(subscribe, DATAID[i].Ip)
+      this.createTCPConnection(DATAID[i].Port, DATAID[i].Ip)
     }
   }
 }

--- a/Electron/Core/RoveProtocol/RovecommManifest.ts
+++ b/Electron/Core/RoveProtocol/RovecommManifest.ts
@@ -36,7 +36,7 @@ export const DATAID = [
   {
     Board: "Drive",
     Ip: "192.168.1.131",
-    Port: 11001,
+    Port: 11111,
     Commands: {
       DriveLeftRight: {
         dataId: 1000,
@@ -205,9 +205,15 @@ export const DATAID = [
   },
   {
     Board: "Nav",
-    Ip: "192.168.1.136",
-    Port: 11005,
-    Commands: {},
+    Ip: "192.168.0.12",
+    Port: 11110,
+    Commands: {
+      GPSPosition: {
+        dataId: 5100,
+        dataType: DataTypes.INT32_T,
+        comments: "lat,long",
+      },
+    },
     Telemetry: {
       GPSPosition: {
         dataId: 5100,

--- a/Electron/Core/RoveProtocol/RovecommManifest.ts
+++ b/Electron/Core/RoveProtocol/RovecommManifest.ts
@@ -205,15 +205,9 @@ export const DATAID = [
   },
   {
     Board: "Nav",
-    Ip: "192.168.0.12",
-    Port: 11110,
-    Commands: {
-      GPSPosition: {
-        dataId: 5100,
-        dataType: DataTypes.INT32_T,
-        comments: "lat,long",
-      },
-    },
+    Ip: "192.168.1.136",
+    Port: 11005,
+    Commands: {},
     Telemetry: {
       GPSPosition: {
         dataId: 5100,

--- a/Electron/Core/RoveProtocol/RovecommManifest.ts
+++ b/Electron/Core/RoveProtocol/RovecommManifest.ts
@@ -29,6 +29,15 @@ export enum DataTypes {
   FLOAT_T = 6,
 }
 
+export enum SystemPackets {
+  PING = 1,
+  PING_REPLY = 2,
+  SUBSCRIBE = 3,
+  UNSUBSCRIBE = 4,
+  INVALID_VERSION = 5,
+  NO_DATA = 6,
+}
+
 // The header length is currently 5 Bytes, stored here for better code in Rovecomm.ts
 export const headerLength = 5
 

--- a/Electron/Core/RoveProtocol/RovecommManifest.ts
+++ b/Electron/Core/RoveProtocol/RovecommManifest.ts
@@ -29,6 +29,9 @@ export enum DataTypes {
   FLOAT_T = 6,
 }
 
+// The header length is currently 5 Bytes, stored here for better code in Rovecomm.ts
+export const headerLength = 5
+
 // Data sizes of the corresponding datatype enumeration
 export const dataSizes = [1, 1, 2, 2, 4, 4, 2]
 

--- a/Electron/Core/RoveProtocol/RovecommManifest.ts
+++ b/Electron/Core/RoveProtocol/RovecommManifest.ts
@@ -36,7 +36,7 @@ export const DATAID = [
   {
     Board: "Drive",
     Ip: "192.168.1.131",
-    Port: 11111,
+    Port: 11001,
     Commands: {
       DriveLeftRight: {
         dataId: 1000,

--- a/Electron/RED/components/GPS.tsx
+++ b/Electron/RED/components/GPS.tsx
@@ -40,7 +40,9 @@ interface IState {
   currentLon: number
   lidar: number
 }
-
+function sendCom() {
+  rovecomm.sendCommand("GPSPosition", [123000, 123000], true)
+}
 class GPS extends Component<IProps, IState> {
   constructor(props: any) {
     super(props)
@@ -98,6 +100,11 @@ class GPS extends Component<IProps, IState> {
               </div>
             )
           })}
+        </div>
+        <div style={container}>
+          <button type="button" onClick={sendCom}>
+            Send Drive Command
+          </button>
         </div>
       </div>
     )

--- a/Electron/RED/components/GPS.tsx
+++ b/Electron/RED/components/GPS.tsx
@@ -40,14 +40,6 @@ interface IState {
   currentLon: number
   lidar: number
 }
-function sendCom() {
-  // this won't work as is, should probably define a test packet to send to self
-  // rovecomm.sendCommand("GPSPosition", [123000, 123000], true)
-  rovecomm.createTCPConnection(11111)
-}
-function sendComUn() {
-  // rovecomm.sendCommand("GPSPosition", [123000, 123000], false)
-}
 class GPS extends Component<IProps, IState> {
   constructor(props: any) {
     super(props)
@@ -105,14 +97,6 @@ class GPS extends Component<IProps, IState> {
               </div>
             )
           })}
-        </div>
-        <div style={container}>
-          <button type="button" onClick={sendCom}>
-            Send TCP
-          </button>
-          <button type="button" onClick={sendComUn}>
-            Send UDP
-          </button>
         </div>
       </div>
     )

--- a/Electron/RED/components/GPS.tsx
+++ b/Electron/RED/components/GPS.tsx
@@ -42,6 +42,10 @@ interface IState {
 }
 function sendCom() {
   rovecomm.sendCommand("GPSPosition", [123000, 123000], true)
+  rovecomm.createTCPConnection(11110, "192.168.0.12")
+}
+function sendComUn() {
+  rovecomm.sendCommand("GPSPosition", [123000, 123000], false)
 }
 class GPS extends Component<IProps, IState> {
   constructor(props: any) {
@@ -103,7 +107,10 @@ class GPS extends Component<IProps, IState> {
         </div>
         <div style={container}>
           <button type="button" onClick={sendCom}>
-            Send Drive Command
+            Send TCP
+          </button>
+          <button type="button" onClick={sendComUn}>
+            Send UDP
           </button>
         </div>
       </div>

--- a/Electron/RED/components/GPS.tsx
+++ b/Electron/RED/components/GPS.tsx
@@ -41,11 +41,12 @@ interface IState {
   lidar: number
 }
 function sendCom() {
-  rovecomm.sendCommand("GPSPosition", [123000, 123000], true)
-  rovecomm.createTCPConnection(11110, "192.168.0.12")
+  // this won't work as is, should probably define a test packet to send to self
+  // rovecomm.sendCommand("GPSPosition", [123000, 123000], true)
+  rovecomm.createTCPConnection(11111)
 }
 function sendComUn() {
-  rovecomm.sendCommand("GPSPosition", [123000, 123000], false)
+  // rovecomm.sendCommand("GPSPosition", [123000, 123000], false)
 }
 class GPS extends Component<IProps, IState> {
   constructor(props: any) {

--- a/Electron/package.json
+++ b/Electron/package.json
@@ -276,6 +276,7 @@
     "@hot-loader/react-dom": "^16.13.0",
     "@reduxjs/toolkit": "^1.4.0",
     "connected-react-router": "^6.6.1",
+    "double-ended-queue": "^2.1.0-0",
     "electron-debug": "^3.1.0",
     "electron-log": "^4.2.2",
     "electron-updater": "^4.3.1",

--- a/Electron/yarn.lock
+++ b/Electron/yarn.lock
@@ -5428,6 +5428,11 @@ dotenv@^8.2.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
   integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
 
+double-ended-queue@^2.1.0-0:
+  version "2.1.0-0"
+  resolved "https://registry.yarnpkg.com/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz#103d3527fd31528f40188130c841efdd78264e5c"
+  integrity sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw=
+
 duplexer3@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/duplexer3/-/duplexer3-0.1.4.tgz#ee01dd1cac0ed3cbc7fdbea37dc0a8f1ce002ce2"


### PR DESCRIPTION
Adding TCP support to the BaseStation implementation of RoveComm.
- Creating TCP connections
- Storing connections to prevent garbage collection from closing them
- Sending messages over a TCP connection
- Reading messages from a TCP connection into a Deque attached to that connection to avoid mangling RoveComm packets by dumping everything into one Deque
- Parsing packets out of each Deque in a reliable fashion