### PR TITLE
Rovecomm3

### DIFF
--- a/assets/RovecommManifest.json
+++ b/assets/RovecommManifest.json
@@ -1,4 +1,5 @@
 {
+  "ManifestFormatVersion": 3,
   "DataTypes": {
     "INT8_T": 0,
     "UINT8_T": 1,
@@ -21,14 +22,12 @@
   },
   "updateRate": 100,
   "ethernetUDPPort": 11000,
-  "subnetIP": [192, 168, 1],
-  "MACaddress": [222, 173, 190, 168, 1],
+  "ethernetTCPPort": 12000,
+  "MACaddressPrefix": [222, 173],
   "headerLength": 6,
   "RovecommManifest": {
     "Drive": {
       "Ip": "192.168.1.134",
-      "Port": 11004,
-      "MAC": "222.173.190.168.1.134",
       "Commands": {
         "DriveLeftRight": {
           "dataId": 1000,
@@ -61,8 +60,6 @@
     },
     "BMS": {
       "Ip": "192.168.1.133",
-      "Port": 11003,
-      "MAC": "222.173.190.168.1.133",
       "Commands": {
         "BMSStop": {
           "dataId": 2000,
@@ -126,8 +123,6 @@
     },
     "Power": {
       "Ip": "192.168.1.132",
-      "Port": 11002,
-      "MAC": "222.173.190.168.1.132",
       "Commands": {
         "MotorBusEnable": {
           "dataId": 3000,
@@ -209,8 +204,6 @@
     },
     "Blackbox": {
       "Ip": "192.168.1.146",
-      "Port": 11015,
-      "MAC": "222.173.190.168.1.146",
       "Commands": {},
       "Telemetry": {
         "BlackboxListening": {
@@ -224,8 +217,6 @@
     },
     "Nav": {
       "Ip": "192.168.1.136",
-      "Port": 11006,
-      "MAC": "222.173.190.168.1.136",
       "Commands": {},
       "Telemetry": {
         "GPSLatLon": {
@@ -251,6 +242,12 @@
           "dataType": "UINT8_T",
           "dataCount": 1,
           "comments": "[Number of satellites]"
+        },
+        "AccelerometerData": {
+          "dataId": 5104,
+          "dataType": "FLOAT_T",
+          "dataCount": 3,
+          "comments": "[xAxis, yAxis, zAxis] Accel in m/s^2"
         }
       },
       "Error": {
@@ -264,8 +261,6 @@
     },
     "Gimbal": {
       "Ip": "192.168.1.135",
-      "Port": 11005,
-      "MAC": "222.173.190.168.1.135",
       "Commands": {
         "LeftDriveGimbalIncrement": {
           "dataId": 6000,
@@ -303,8 +298,6 @@
     },
     "Multimedia": {
       "Ip": "192.168.1.140",
-      "Port": 11010,
-      "MAC": "222.173.190.168.1.140",
       "Commands": {
         "LEDRGB": {
           "dataId": 7000,
@@ -352,8 +345,6 @@
     },
     "Arm": {
       "Ip": "192.168.1.131",
-      "Port": 11001,
-      "MAC": "222.173.190.168.1.131",
       "Commands": {
         "ArmVelocityControl": {
           "dataId": 8000,
@@ -483,8 +474,6 @@
     },
     "ScienceActuation": {
       "Ip": "192.168.1.137",
-      "Port": 11007,
-      "MAC": "222.173.190.168.1.137",
       "Commands": {
         "SensorAxis": {
           "dataId": 9000,
@@ -566,8 +555,6 @@
     },
     "ScienceSensors": {
       "Ip": "192.168.1.138",
-      "Port": 11008,
-      "MAC": "222.173.190.168.1.138",
       "Commands": {
         "FluorometerLEDs": {
           "dataId": 10000,
@@ -580,12 +567,18 @@
           "dataType": "INT8_T",
           "dataCount": 1,
           "comments": "Sign of value determines direction"
+        },
+        "ReqFluorometer": {
+          "dataId": 10002,
+          "dataType": "UINT8_T",
+          "dataCount": 1,
+          "comments": "Request a new Fluorometer reading"
         }
       },
       "Telemetry": {
         "FluorometerData": {
           "dataId": 10100,
-          "dataType": "FLOAT_T",
+          "dataType": "UINT16_T",
           "dataCount": 3648,
           "comments": "Diode readings from sensor"
         },
@@ -624,8 +617,6 @@
     },
     "Autonomy": {
       "Ip": "192.168.1.139",
-      "Port": 11009,
-      "MAC": "222.173.190.168.1.139",
       "Commands": {
         "StartAutonomy": {
           "dataId": 11000,
@@ -694,24 +685,45 @@
     },
     "Camera1": {
       "Ip": "192.168.1.141",
-      "Port": 11011,
-      "MAC": "222.173.190.168.1.141",
-      "Commands": {},
-      "Telemetry": {},
-      "Error": {}
+      "Commands": {
+        "ChangeCameras": {
+          "dataId": 12000,
+          "dataType": "UINT8_T",
+          "dataCount": 2,
+          "comments": "Change which camera a feed is looking at. [0] is the feed, [1] is the camera to view."
+        }
+      },
+      "Telemetry": {
+        "AvailableCameras": {
+          "dataId": 12100,
+          "dataType": "UINT8_T",
+          "dataCount": 1,
+          "comments": "Bitmask values for which cameras are able to stream. LSB is Camera 0, MSB is Camera 7."
+        },
+        "StreamingCameras": {
+          "dataId": 12101,
+          "dataType": "UINT8_T",
+          "dataCount": 4,
+          "comments": "Which cameras the system is currently streaming on each port"
+        }
+      },
+      "Error": {
+        "CameraUnavailable": {
+          "dataId": 12200,
+          "dataType": "UINT8_T",
+          "dataCount": 1,
+          "comments": "Camera has errored and stopped streaming. [0] is ID of camera as an integer (not bitmask)."
+        }
+      }
     },
     "Camera2": {
       "Ip": "192.168.1.142",
-      "Port": 11012,
-      "MAC": "222.173.190.168.1.142",
       "Commands": {},
       "Telemetry": {},
       "Error": {}
     },
     "Heater": {
       "Ip": "192.168.1.144",
-      "Port": 11014,
-      "MAC": "222.173.190.168.1.144",
       "Commands": {
         "HeaterToggle": {
           "dataId": 15000,
@@ -745,8 +757,6 @@
     },
     "SignalStack": {
       "Ip": "192.168.1.145",
-      "Port": 11015,
-      "MAC": "222.173.190.168.1.145",
       "Commands": {
         "SignalsRotate": {
           "dataId": 16000,

--- a/assets/RovecommManifest.json
+++ b/assets/RovecommManifest.json
@@ -1,5 +1,5 @@
 {
-  "ManifestFormatVersion": 3,
+  "ManifestSpecVersion": 3,
   "DataTypes": {
     "INT8_T": 0,
     "UINT8_T": 1,
@@ -27,7 +27,7 @@
   "headerLength": 6,
   "RovecommManifest": {
     "Drive": {
-      "Ip": "192.168.1.134",
+      "Ip": "192.168.2.103",
       "Commands": {
         "DriveLeftRight": {
           "dataId": 1000,
@@ -59,7 +59,7 @@
       "Error": {}
     },
     "BMS": {
-      "Ip": "192.168.1.133",
+      "Ip": "192.168.2.100",
       "Commands": {
         "BMSStop": {
           "dataId": 2000,
@@ -122,7 +122,7 @@
       }
     },
     "Power": {
-      "Ip": "192.168.1.132",
+      "Ip": "192.168.2.101",
       "Commands": {
         "MotorBusEnable": {
           "dataId": 3000,
@@ -203,7 +203,7 @@
       }
     },
     "Blackbox": {
-      "Ip": "192.168.1.146",
+      "Ip": "192.168.2.102",
       "Commands": {},
       "Telemetry": {
         "BlackboxListening": {
@@ -216,7 +216,7 @@
       "Error": {}
     },
     "Nav": {
-      "Ip": "192.168.1.136",
+      "Ip": "192.168.2.104",
       "Commands": {},
       "Telemetry": {
         "GPSLatLon": {
@@ -260,7 +260,7 @@
       }
     },
     "Gimbal": {
-      "Ip": "192.168.1.135",
+      "Ip": "192.168.2.106",
       "Commands": {
         "LeftDriveGimbalIncrement": {
           "dataId": 6000,
@@ -297,7 +297,7 @@
       "Error": {}
     },
     "Multimedia": {
-      "Ip": "192.168.1.140",
+      "Ip": "192.168.2.105",
       "Commands": {
         "LEDRGB": {
           "dataId": 7000,
@@ -344,7 +344,7 @@
       }
     },
     "Arm": {
-      "Ip": "192.168.1.131",
+      "Ip": "192.168.2.107",
       "Commands": {
         "ArmVelocityControl": {
           "dataId": 8000,
@@ -473,7 +473,7 @@
       }
     },
     "ScienceActuation": {
-      "Ip": "192.168.1.137",
+      "Ip": "192.168.2.108",
       "Commands": {
         "SensorAxis": {
           "dataId": 9000,
@@ -554,7 +554,7 @@
       }
     },
     "ScienceSensors": {
-      "Ip": "192.168.1.138",
+      "Ip": "192.168.3.101",
       "Commands": {
         "FluorometerLEDs": {
           "dataId": 10000,
@@ -616,7 +616,7 @@
       "Error": {}
     },
     "Autonomy": {
-      "Ip": "192.168.1.139",
+      "Ip": "192.168.3.100",
       "Commands": {
         "StartAutonomy": {
           "dataId": 11000,
@@ -684,7 +684,7 @@
       "Error": {}
     },
     "Camera1": {
-      "Ip": "192.168.1.141",
+      "Ip": "192.168.4.100",
       "Commands": {
         "ChangeCameras": {
           "dataId": 12000,
@@ -717,13 +717,13 @@
       }
     },
     "Camera2": {
-      "Ip": "192.168.1.142",
+      "Ip": "192.168.4.101",
       "Commands": {},
       "Telemetry": {},
       "Error": {}
     },
     "Heater": {
-      "Ip": "192.168.1.144",
+      "Ip": "192.168.2.109",
       "Commands": {
         "HeaterToggle": {
           "dataId": 15000,
@@ -756,7 +756,7 @@
       }
     },
     "SignalStack": {
-      "Ip": "192.168.1.145",
+      "Ip": "192.168.3.102",
       "Commands": {
         "SignalsRotate": {
           "dataId": 16000,
@@ -784,13 +784,13 @@
     }
   },
   "NetworkDevices": {
-    "BasestationSwitch": { "Ip": "192.168.1.80" },
-    "RoverSwitch": { "Ip": "192.168.1.81" },
-    "Rover900MHzRocket": { "Ip": "192.168.1.82" },
-    "Basestation900MHzRocket": { "Ip": "192.168.1.83" },
-    "Rover5GHzRocket": { "Ip": "192.168.1.84" },
-    "Basestation5GHzRocket": { "Ip": "192.168.1.85" },
-    "Rover2_4GHzRocket": { "Ip": "192.168.1.86" },
-    "Basestation2_4GHzRocket": { "Ip": "192.168.1.87"}
+    "BasestationSwitch": { "Ip": "192.168.126.1" },
+    "RoverSwitch": { "Ip": "192.168.126.2" },
+    "Rover900MHzRocket": { "Ip": "192.168.126.11" },
+    "Basestation900MHzRocket": { "Ip": "192.168.126.10" },
+    "Rover5GHzRocket": { "Ip": "192.168.126.31" },
+    "Basestation5GHzRocket": { "Ip": "192.168.126.30" },
+    "Rover2_4GHzRocket": { "Ip": "192.168.126.21" },
+    "Basestation2_4GHzRocket": { "Ip": "192.168.126.20"}
   }
 }

--- a/src/Core/RoveProtocol/Rovecomm.ts
+++ b/src/Core/RoveProtocol/Rovecomm.ts
@@ -10,9 +10,7 @@ import path from 'path';
 // Make sure header length is correct in the manifest for the appropriate
 // rovecomm (5 for rovecomm2, 6 for rovecomm2.5)
 /* eslint-disable import/no-cycle */
-import { parseHeader, createHeader, TCPParseWrapper } from './Rovecomm25';
-
-const VersionNumber = 25;
+import { parseHeader, createHeader, TCPParseWrapper, VersionNumber } from './Rovecomm3';
 
 export let RovecommManifest: any = {};
 export let dataSizes: number[] = [];
@@ -21,6 +19,7 @@ export let headerLength = 0;
 export let SystemPackets: any = {};
 export let NetworkDevices: any = {};
 let ethernetUDPPort = 11000;
+let ethernetTCPPort = 12000;
 const filepath = path.join(__dirname, '../assets/RovecommManifest.json');
 
 if (fs.existsSync(filepath)) {
@@ -32,7 +31,7 @@ if (fs.existsSync(filepath)) {
   SystemPackets = manifest.SystemPackets;
   NetworkDevices = manifest.NetworkDevices;
   ethernetUDPPort = manifest.ethernetUDPPort;
-  console.log(typeof RovecommManifest);
+  ethernetTCPPort = manifest.ethernetTCPPort;
 }
 
 // There is a fundamental implementation difference between these required imports
@@ -416,7 +415,7 @@ class Rovecomm extends EventEmitter {
       if (Object.prototype.hasOwnProperty.call(RovecommManifest, board)) {
         if (dataIdStr in RovecommManifest[board].Commands) {
           destinationIp = RovecommManifest[board].Ip;
-          port = RovecommManifest[board].Port;
+          port = ethernetTCPPort;
           dataType = RovecommManifest[board].Commands[dataIdStr].dataType;
           dataId = RovecommManifest[board].Commands[dataIdStr].dataId;
           found = true;
@@ -539,7 +538,7 @@ class Rovecomm extends EventEmitter {
     await new Promise((resolve) => setTimeout(() => resolve(true), 300));
     for (const board in RovecommManifest) {
       if (Object.prototype.hasOwnProperty.call(RovecommManifest, board)) {
-        this.createTCPConnection(RovecommManifest[board].Port, RovecommManifest[board].Ip);
+        this.createTCPConnection(ethernetTCPPort, RovecommManifest[board].Ip);
       }
     }
   }

--- a/src/Core/RoveProtocol/Rovecomm2.ts
+++ b/src/Core/RoveProtocol/Rovecomm2.ts
@@ -9,7 +9,7 @@ import { parse } from './Rovecomm';
 export let dataSizes: any = [];
 export let DataTypes: any = {};
 const filepath = path.join(__dirname, '../assets/RovecommManifest.json');
-const VersionNumber = 2;
+export const VersionNumber = 2;
 const headerLength = 5;
 
 if (fs.existsSync(filepath)) {

--- a/src/Core/RoveProtocol/Rovecomm3.ts
+++ b/src/Core/RoveProtocol/Rovecomm3.ts
@@ -11,7 +11,7 @@ export let DataTypes: any = {};
 const headerLength = 6;
 
 const filepath = path.join(__dirname, '../assets/RovecommManifest.json');
-export const VersionNumber = 25;
+export const VersionNumber = 3;
 
 if (fs.existsSync(filepath)) {
   const manifest = JSON.parse(fs.readFileSync(filepath).toString());

--- a/src/RON/components/PingTool.tsx
+++ b/src/RON/components/PingTool.tsx
@@ -56,7 +56,7 @@ const name: CSS.Properties = {
   whiteSpace: 'nowrap',
 };
 const num: CSS.Properties = {
-  width: '10%',
+  width: '20%',
   textAlign: 'center',
   display: 'block',
   textOverflow: 'ellipsis',
@@ -167,6 +167,7 @@ class PingTool extends Component<IProps, IState> {
           [device]: {
             ...prevState.devices[device],
             ping: delay,
+            autoPing: delay !== -1,
           },
         },
       }));
@@ -246,7 +247,7 @@ class PingTool extends Component<IProps, IState> {
                         {device}
                       </div>
                       <div style={ColorStyleConverter(ping, min, cutoff, max, greenHue, redHue, num)}>
-                        {Ip.split('.')[3]}
+                        {`${Ip.split('.')[2]}.${Ip.split('.')[3]}`}
                       </div>
                       <div style={ColorStyleConverter(ping, min, cutoff, max, greenHue, redHue, num)}>
                         {this.state.devices[device].ping}


### PR DESCRIPTION
Update manifest format and allow all four octets of IPs to change. Prepare for spanning tree. Band-aid fixed the Ping Tool creating thousands of subprocesses.